### PR TITLE
Bump version to 0.6.10 and update twm-faust

### DIFF
--- a/kaspr/__init__.py
+++ b/kaspr/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.6.9"
+__version__ = "0.6.10"
 
 from .core.app import KasprApp
 from .scheduler.manager import MessageScheduler

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 pytz
 pyyaml==6.0
-twm-faust[rocksdict,prometheus]>=1.16.6,<1.17.0
+twm-faust[rocksdict,prometheus]>=1.16.7,<1.17.0
 python-benedict==0.33.2
 marshmallow==3.21.3
 mmh3==5.1.0


### PR DESCRIPTION
This pull request makes a minor update to the project version, incrementing it from 0.6.9 to 0.6.10 in the `kaspr/__init__.py` file.