### PR TITLE
Add signal endpoint and web_host setting

### DIFF
--- a/kaspr/__init__.py
+++ b/kaspr/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.6.12"
+__version__ = "0.6.13"
 
 from .core.app import KasprApp
 from .scheduler.manager import MessageScheduler

--- a/kaspr/app.py
+++ b/kaspr/app.py
@@ -36,3 +36,4 @@ app.monitor = PrometheusMonitor(
 
 # Add web endpoints
 app.web.blueprints.add('/status', 'kaspr.blueprints.status.blueprint')
+app.web.blueprints.add('/signal', 'kaspr.blueprints.signal.blueprint')

--- a/kaspr/blueprints/signal.py
+++ b/kaspr/blueprints/signal.py
@@ -1,0 +1,21 @@
+"""HTTP endpoint to handle actionable signals for the app."""
+
+from collections import defaultdict
+from typing import Any, List, MutableMapping, Set
+from faust import web
+from faust.types.tuples import TP
+
+__all__ = ["Signal", "blueprint"]
+
+TPMap = MutableMapping[str, List[int]]
+
+blueprint = web.Blueprint("signal")
+
+@blueprint.route("/rebalance", name="rebalance")
+class Signal(web.View):
+    """App signal information."""
+
+    async def post(self, request: web.Request, **kwargs: Any) -> Any:
+        """Handle signals sent to the app."""
+        self.app.log.info("Received rebalance signal!")
+        self.app.consumer.request_rejoin()

--- a/kaspr/blueprints/status.py
+++ b/kaspr/blueprints/status.py
@@ -1,4 +1,4 @@
-"""HTTP endpoint showing health/status of various components the app."""
+"""HTTP endpoint showing state of various components the app."""
 
 from collections import defaultdict
 from typing import List, MutableMapping, Set
@@ -27,6 +27,7 @@ class Status(web.View):
         assignor = self.app.assignor
         return self.json(
             {
+                "leader": self.app.is_leader(),
                 "rebalancing": self.app.rebalancing,
                 "recovering": self.app.tables.recovery.in_recovery,
                 "assignment": {

--- a/kaspr/types/settings.py
+++ b/kaspr/types/settings.py
@@ -282,6 +282,9 @@ SCHEDULER_JANITOR_HIGHWATER_OFFSET_SECONDS = float(
 #: Base http path for serving web requests
 WEB_BASE_PATH = _getenv("WEB_BASE_PATH", "")
 
+#: Web hostname or IP address of the web server.
+WEB_HOST: str = _getenv("WEB_HOST", socket.gethostname())
+
 #: Port number between 1024 and 65535 to use for the web server.
 WEB_PORT: int = int(_getenv("WEB_PORT", "6066"))
 
@@ -363,6 +366,7 @@ class CustomSettings(Settings):
     scheduler_janitor_highwater_offset_seconds: float = SCHEDULER_JANITOR_HIGHWATER_OFFSET_SECONDS
 
     web_base_path: str = WEB_BASE_PATH
+    web_host: str = WEB_HOST
     web_port: int = WEB_PORT
     web_metrics_base_path: str = WEB_METRICS_BASE_PATH
 
@@ -415,6 +419,7 @@ class CustomSettings(Settings):
         scheduler_janitor_clean_interval_seconds: Seconds = None,
         scheduler_janitor_highwater_offset_seconds: Seconds = None,
         web_base_path: str = None,
+        web_host: str = None,
         web_port: int = None,
         web_metrics_base_path: str = None,
         definitions_dir: str = None,
@@ -488,6 +493,9 @@ class CustomSettings(Settings):
         if table_dir is not None:
             self.table_dir = table_dir
 
+        if web_host is not None:
+            self.web_host = web_host
+
         if web_port is not None:
             self.web_port = web_port
 
@@ -508,6 +516,7 @@ class CustomSettings(Settings):
             stream_buffer_maxsize=self.stream_buffer_maxsize,
             stream_recovery_delay=self.stream_recovery_delay,
             stream_wait_empty=self.stream_wait_empty,
+            web_host=self.web_host,
             web_port=self.web_port,
             **kwargs,
         )


### PR DESCRIPTION
Introduces a new '/signal' HTTP endpoint for handling actionable signals, such as triggering a rebalance. Adds the WEB_HOST setting to allow configuration of the web server's hostname or IP address. The status endpoint now also reports the app's leader status.