### PR TITLE
Bump to v0.8.2 and update twm-faust

### DIFF
--- a/kaspr/__init__.py
+++ b/kaspr/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.8.1"
+__version__ = "0.8.2"
 
 from .core.app import KasprApp
 from .scheduler.manager import MessageScheduler

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 pytz
 pyyaml==6.0.3
-twm-faust[rocksdict,prometheus]>=1.17.6,<1.18.0
+twm-faust[rocksdict,prometheus]>=1.17.7,<1.18.0
 python-benedict==0.33.2
 marshmallow==3.21.3
 mmh3==5.1.0


### PR DESCRIPTION
This pull request makes a minor update to the project version, incrementing it from 0.8.1 to 0.8.2 in the `kaspr/__init__.py` file.