### PR TITLE
Bump version and handle janitor highwater None

### DIFF
--- a/kaspr/__init__.py
+++ b/kaspr/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.1"
+__version__ = "0.10.2"
 
 from .core.app import KasprApp
 from .scheduler.manager import MessageScheduler

--- a/kaspr/scheduler/manager.py
+++ b/kaspr/scheduler/manager.py
@@ -453,6 +453,7 @@ class MessageScheduler(MessageSchedulerT, Service):
         for partition, janitor in self._janitors.items():
             pt = PT(SchedulerPart.janitor, partition)
             checkpoint = self.checkpoints.get(pt, default=janitor.default_checkpoint)
+            janitor_highwater = janitor.highwater
             _data.append(
                 tuple(
                     [
@@ -461,7 +462,9 @@ class MessageScheduler(MessageSchedulerT, Service):
                         checkpoint.time_key,
                         checkpoint.sequence,
                         prettydate(checkpoint),
-                        locdiff(janitor.highwater, checkpoint),
+                        locdiff(janitor_highwater, checkpoint)
+                        if janitor_highwater is not None
+                        else "-",
                     ]
                 )
             )
@@ -504,6 +507,7 @@ class MessageScheduler(MessageSchedulerT, Service):
         for janitor in self._janitors.values():
             last = janitor.last_location
             if last:
+                janitor_highwater = janitor.highwater
                 _data.append(
                     tuple(
                         [
@@ -512,7 +516,9 @@ class MessageScheduler(MessageSchedulerT, Service):
                             last.time_key,
                             last.sequence,
                             prettydate(last),
-                            locdiff(janitor.highwater, last),
+                            locdiff(janitor_highwater, last)
+                            if janitor_highwater is not None
+                            else "-",
                             self.monitor.janitor_state(janitor).messages_removed,
                             "-",
                             "-",


### PR DESCRIPTION
This pull request primarily addresses improved handling of cases where a janitor's `highwater` attribute may be `None` in the `MessageScheduler`'s logging utilities. It also bumps the package version to reflect these changes.

Improvements to logging robustness:

* Updated both `_checkpoints_logtable` and `_stats_logtable` methods in `kaspr/scheduler/manager.py` to check if `janitor.highwater` is `None` before calling `locdiff`, outputting `"-"` instead of raising an error if `highwater` is missing. [[1]](diffhunk://#diff-bba188f9b73a9aa87d27deffec3081adc17a569afa3ed75656e1b56198a63664R456) [[2]](diffhunk://#diff-bba188f9b73a9aa87d27deffec3081adc17a569afa3ed75656e1b56198a63664L464-R467) [[3]](diffhunk://#diff-bba188f9b73a9aa87d27deffec3081adc17a569afa3ed75656e1b56198a63664R510) [[4]](diffhunk://#diff-bba188f9b73a9aa87d27deffec3081adc17a569afa3ed75656e1b56198a63664L515-R521)

Version update:

* Incremented the package version from `0.10.1` to `0.10.2` in `kaspr/__init__.py` to reflect these changes.