### PR TITLE
Add support for REPLACE scheduling

### DIFF
--- a/kaspr/__init__.py
+++ b/kaspr/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.2"
+__version__ = "0.10.3"
 
 from .core.app import KasprApp
 from .scheduler.manager import MessageScheduler

--- a/kaspr/scheduler/janitor.py
+++ b/kaspr/scheduler/janitor.py
@@ -314,6 +314,7 @@ class Janitor(Service):
             await self._maybe_wait()
             # TODO: Confirm stream is "paused" during rebalance and recovery
             timetable = self.app.scheduler.timetable
+            schedule_index = self.app.scheduler.schedule_index
             partition, timekey, sequence = (
                 location.partition,
                 location.time_key,
@@ -322,12 +323,29 @@ class Janitor(Service):
 
             if sequence >= 0:
                 message_key = create_message_key(location)
+                message = timetable.get_for_partition(message_key, partition=partition)
                 self.track_removal(location)
                 timetable.del_for_partition(
                     message_key,
                     partition=partition,
                     callback=self.on_changelog_sent(location),
                 )
+                # Remove reverse index entry if this scheduled row was keyed by request_id.
+                rid = ((message or {}).get("__kms") or {}).get("rid")
+                if rid:
+                    index_entry = schedule_index.get_for_partition(
+                        rid, partition=partition
+                    )
+                    if index_entry:
+                        idx_timekey = index_entry.get("tk")
+                        idx_sequence = index_entry.get("seq")
+                        if (
+                            idx_timekey is not None
+                            and idx_sequence is not None
+                            and int(idx_timekey) == int(timekey)
+                            and int(idx_sequence) == int(sequence)
+                        ):
+                            schedule_index.del_for_partition(rid, partition=partition)
 
             elif sequence < 0:
                 self.track_removal(location)

--- a/kaspr/scheduler/manager.py
+++ b/kaspr/scheduler/manager.py
@@ -1,4 +1,6 @@
 import asyncio
+import hashlib
+import json
 from collections import defaultdict
 from math import floor
 from mode import Service
@@ -69,6 +71,10 @@ class MessageScheduler(MessageSchedulerT, Service):
     #: (since startup by partition)
     replaced_total: Mapping[int, int]
 
+    #: Number of REPLACE actions that were strict no-ops because
+    #: the existing schedule was identical (since startup by partition)
+    replace_noop_total: Mapping[int, int]
+
     #: Number of CANCEL actions that canceled an existing schedule
     #: (since startup by partition)
     canceled_total: Mapping[int, int]
@@ -84,6 +90,7 @@ class MessageScheduler(MessageSchedulerT, Service):
         self.scheduled_total = defaultdict(int)
         self.instant_send_total = defaultdict(int)
         self.replaced_total = defaultdict(int)
+        self.replace_noop_total = defaultdict(int)
         self.canceled_total = defaultdict(int)
         self._dispatchers = {}
         self._janitors = {}
@@ -434,6 +441,50 @@ class MessageScheduler(MessageSchedulerT, Service):
             topic.get_topic_name(), str(value).encode()
         ).partition
 
+    def _decode_if_bytes(self, value: Any) -> Any:
+        return value.decode() if isinstance(value, bytes) else value
+
+    def _normalize_headers(self, headers: Optional[Mapping[Any, Any]]) -> Optional[Mapping[Any, Any]]:
+        if not headers:
+            return headers
+        return {
+            self._decode_if_bytes(k): self._decode_if_bytes(v)
+            for k, v in headers.items()
+        }
+
+    def _build_message_entry(
+        self,
+        event: EventT,
+        destination: str,
+        request_id: Optional[str] = None,
+    ) -> Mapping[str, Any]:
+        kms_meta = {"d": destination}
+        if request_id:
+            kms_meta["rid"] = request_id
+        return {
+            "k": self._decode_if_bytes(event.key),
+            "v": self._decode_if_bytes(event.value),
+            "h": self._normalize_headers(event.headers),
+            "__kms": kms_meta,
+        }
+
+    def _schedule_fingerprint(self, time_key: int, message_entry: Mapping[str, Any]) -> str:
+        """Compute strict identity hash for schedule replacement no-op checks."""
+        payload = {
+            "tk": int(time_key),
+            "d": (message_entry.get("__kms") or {}).get("d"),
+            "k": self._decode_if_bytes(message_entry.get("k")),
+            "v": self._decode_if_bytes(message_entry.get("v")),
+            "h": self._normalize_headers(message_entry.get("h")),
+        }
+        canonical = json.dumps(
+            payload,
+            sort_keys=True,
+            separators=(",", ":"),
+            default=str,
+        )
+        return hashlib.sha256(canonical.encode()).hexdigest()
+
     def _consolidate_table_keys(self, data: TableDataT) -> Iterator[List[str]]:
         """Format terminal log table to reduce noise from duplicate keys.
 
@@ -524,6 +575,7 @@ class MessageScheduler(MessageSchedulerT, Service):
                             self.scheduled_total[partition],
                             self.instant_send_total[partition],
                             self.replaced_total[partition],
+                            self.replace_noop_total[partition],
                             self.canceled_total[partition],
                         ]
                     )
@@ -548,6 +600,7 @@ class MessageScheduler(MessageSchedulerT, Service):
                             "-",
                             "-",
                             "-",
+                            "-",
                         ]
                     )
                 )
@@ -565,6 +618,7 @@ class MessageScheduler(MessageSchedulerT, Service):
                 "total scheduled",
                 "immediate sends",
                 "replace hits",
+                "replace no-ops",
                 "cancel hits",
             ],
         )
@@ -621,6 +675,32 @@ class MessageScheduler(MessageSchedulerT, Service):
                 else request_id
             )
 
+            replace_time_key: Optional[int] = None
+            replace_destination: Optional[str] = None
+            replace_message_entry: Optional[Mapping[str, Any]] = None
+            replace_fingerprint: Optional[str] = None
+
+            if _action == SCHEDULER_ACTION_REPLACE:
+                if not deliver_at or not deliver_to:
+                    self.log.warning(
+                        "REPLACE: missing deliver_at or deliver_to, skipping"
+                    )
+                    continue
+                try:
+                    replace_time_key = int(self._decode_if_bytes(deliver_at))
+                except (TypeError, ValueError):
+                    self.log.warning("REPLACE: invalid deliver_at, skipping")
+                    continue
+                replace_destination = self._decode_if_bytes(deliver_to)
+                replace_message_entry = self._build_message_entry(
+                    event,
+                    destination=replace_destination,
+                    request_id=_request_id,
+                )
+                replace_fingerprint = self._schedule_fingerprint(
+                    replace_time_key, replace_message_entry
+                )
+
             if _action in (SCHEDULER_ACTION_CANCEL, SCHEDULER_ACTION_REPLACE):
                 if not _request_id:
                     self.log.warning(f"{_action}: missing request_id, skipping")
@@ -638,6 +718,38 @@ class MessageScheduler(MessageSchedulerT, Service):
                     loc_sequence = index_entry["seq"]
                     location = TTLocation(partition, loc_time_key, loc_sequence)
                     message_key = create_message_key(location)
+
+                    if _action == SCHEDULER_ACTION_REPLACE:
+                        existing_fingerprint = index_entry.get("fp")
+                        if not existing_fingerprint:
+                            existing_entry = timetable.get_for_partition(
+                                message_key, partition=partition
+                            )
+                            if existing_entry:
+                                existing_fingerprint = self._schedule_fingerprint(
+                                    loc_time_key, existing_entry
+                                )
+                        if (
+                            existing_fingerprint
+                            and replace_fingerprint
+                            and existing_fingerprint == replace_fingerprint
+                        ):
+                            if not index_entry.get("fp"):
+                                updated_index_entry = dict(index_entry)
+                                updated_index_entry["fp"] = existing_fingerprint
+                                schedule_index.update_for_partition(
+                                    {_request_id: updated_index_entry},
+                                    partition=partition,
+                                )
+                            self.replace_noop_total[partition] += 1
+                            self.monitor.on_message_replace_noop(
+                                partition=partition
+                            )
+                            self.log.dev(
+                                f"REPLACE: no-op for {_request_id}; identical schedule already exists"
+                            )
+                            continue
+
                     timetable.del_for_partition(message_key, partition=partition)
                     schedule_index.del_for_partition(_request_id, partition=partition)
                     # Decrement the live count for this timekey
@@ -674,8 +786,8 @@ class MessageScheduler(MessageSchedulerT, Service):
                         f"{_action}: missing deliver_at or deliver_to, skipping"
                     )
                     continue
-                _topic_name = deliver_to.decode()
-                time_key = str(deliver_at.decode())
+                _topic_name = self._decode_if_bytes(deliver_to)
+                time_key = str(self._decode_if_bytes(deliver_at))
 
                 # a message attemping to be scheduled at or before the current timekey
                 # is considered past due. We send past due messages immediately.
@@ -698,26 +810,16 @@ class MessageScheduler(MessageSchedulerT, Service):
                 location = TTLocation(partition, int(time_key), sequence=message_total)
                 message_key = create_message_key(location)
 
-                kms_meta = {"d": deliver_to.decode()}
-                if _request_id:
-                    kms_meta["rid"] = _request_id
+                if _action == SCHEDULER_ACTION_REPLACE and replace_message_entry:
+                    message_entry = replace_message_entry
+                else:
+                    message_entry = self._build_message_entry(
+                        event,
+                        destination=_topic_name,
+                        request_id=_request_id,
+                    )
 
-                message_entry = {
-                    "k": event.key.decode()
-                    if isinstance(event.key, bytes)
-                    else event.key,
-                    "v": event.value.decode()
-                    if isinstance(event.value, bytes)
-                    else event.value,
-                    "h": {
-                        (k.decode() if isinstance(k, bytes) else k):
-                        (v.decode() if isinstance(v, bytes) else v)
-                        for k, v in event.headers.items()
-                    }
-                    if event.headers
-                    else event.headers,
-                    "__kms": kms_meta,
-                }
+                entry_fingerprint = self._schedule_fingerprint(int(time_key), message_entry)
                 live_key = f"{time_key}{TK_LIVE_SUFFIX}"
                 live_value = timetable.get_for_partition(live_key, partition=partition)
                 live_count = self._live_count_from_value(live_value)
@@ -739,6 +841,7 @@ class MessageScheduler(MessageSchedulerT, Service):
                             _request_id: {
                                 "tk": int(time_key),
                                 "seq": message_total,
+                                "fp": entry_fingerprint,
                             }
                         },
                         partition=partition,
@@ -790,6 +893,7 @@ class MessageScheduler(MessageSchedulerT, Service):
                 headers.update(scheduler_headers)
                 _partition = self._request_partition(actions_topic, request_id)
                 send_kwargs = {"partition": _partition} if _partition is not None else {}
+                print(f"Distributing message with action {_action} to partition {_partition}")
                 await actions_topic.send(
                     key=event.message.key,
                     value=event.message.value,
@@ -874,6 +978,7 @@ class MessageScheduler(MessageSchedulerT, Service):
             headers.update(scheduler_headers)
             _partition = self._request_partition(actions_topic, request_id)
             send_kwargs = {"partition": _partition} if _partition is not None else {}
+            print(f"Distributing message with action {_action} to partition {_partition}")
             await actions_topic.send(
                 key=event.message.key,
                 value=event.message.value,

--- a/kaspr/scheduler/manager.py
+++ b/kaspr/scheduler/manager.py
@@ -36,6 +36,7 @@ json_codec = get_codec("json")
 
 SCHEDULER_ACTION_ADD = "ADD"
 SCHEDULER_ACTION_CANCEL = "CANCEL"
+SCHEDULER_ACTION_REPLACE = "REPLACE"
 
 H_SCHEDULER_ACTION = "x-scheduler-action"
 H_SCHEDULER_DELIVER_AT = "x-scheduler-deliver-at"
@@ -64,6 +65,14 @@ class MessageScheduler(MessageSchedulerT, Service):
     #: already past due (since startup by partition)
     instant_send_total: Mapping[int, int]
 
+    #: Number of REPLACE actions that replaced an existing schedule
+    #: (since startup by partition)
+    replaced_total: Mapping[int, int]
+
+    #: Number of CANCEL actions that canceled an existing schedule
+    #: (since startup by partition)
+    canceled_total: Mapping[int, int]
+
     #: cached topics of delivery destinations
     _out_topics: Mapping[str, TopicT]
 
@@ -74,6 +83,8 @@ class MessageScheduler(MessageSchedulerT, Service):
         self.timetable_recovered = Event()
         self.scheduled_total = defaultdict(int)
         self.instant_send_total = defaultdict(int)
+        self.replaced_total = defaultdict(int)
+        self.canceled_total = defaultdict(int)
         self._dispatchers = {}
         self._janitors = {}
         self._out_topics = {}
@@ -412,6 +423,17 @@ class MessageScheduler(MessageSchedulerT, Service):
             return payload
         return {"count": next_count}
 
+    def _request_partition(self, topic: TopicT, request_id: Any) -> Optional[int]:
+        """Compute stable action partition for a request id."""
+        if request_id is None:
+            return None
+        value = request_id.decode() if isinstance(request_id, bytes) else request_id
+        if value is None:
+            return None
+        return self.app.producer.key_partition(
+            topic.get_topic_name(), str(value).encode()
+        ).partition
+
     def _consolidate_table_keys(self, data: TableDataT) -> Iterator[List[str]]:
         """Format terminal log table to reduce noise from duplicate keys.
 
@@ -501,6 +523,8 @@ class MessageScheduler(MessageSchedulerT, Service):
                             ).messages_delivered,
                             self.scheduled_total[partition],
                             self.instant_send_total[partition],
+                            self.replaced_total[partition],
+                            self.canceled_total[partition],
                         ]
                     )
                 )
@@ -522,6 +546,8 @@ class MessageScheduler(MessageSchedulerT, Service):
                             self.monitor.janitor_state(janitor).messages_removed,
                             "-",
                             "-",
+                            "-",
+                            "-",
                         ]
                     )
                 )
@@ -538,6 +564,8 @@ class MessageScheduler(MessageSchedulerT, Service):
                 "deliveries",
                 "total scheduled",
                 "immediate sends",
+                "replace hits",
+                "cancel hits",
             ],
         )
 
@@ -582,53 +610,70 @@ class MessageScheduler(MessageSchedulerT, Service):
             deliver_to: bytes = event.headers.pop(H_SCHEDULER_DELIVER_TO, None)
             request_id: bytes = event.headers.pop(H_SCHEDULER_REQUEST_ID, None)
 
-            _action = action.decode()
+            _action = action.decode() if isinstance(action, bytes) else action
             partition = event.message.partition
             timetable = self.app.scheduler.timetable
             schedule_index = self.app.scheduler.schedule_index
 
-            if _action == SCHEDULER_ACTION_CANCEL:
-                _request_id = (
-                    request_id.decode()
-                    if isinstance(request_id, bytes)
-                    else request_id
-                )
+            _request_id = (
+                request_id.decode()
+                if isinstance(request_id, bytes)
+                else request_id
+            )
+
+            if _action in (SCHEDULER_ACTION_CANCEL, SCHEDULER_ACTION_REPLACE):
                 if not _request_id:
-                    self.log.warning("Cancel: missing request_id, skipping")
+                    self.log.warning(f"{_action}: missing request_id, skipping")
                     continue
                 index_entry = schedule_index.get_for_partition(
                     _request_id, partition=partition
                 )
-                if not index_entry:
+                if _action == SCHEDULER_ACTION_CANCEL and not index_entry:
                     self.log.warning(
                         f"Cancel: request_id {_request_id} not found"
                     )
                     continue
-                loc_time_key = index_entry["tk"]
-                loc_sequence = index_entry["seq"]
-                location = TTLocation(partition, loc_time_key, loc_sequence)
-                message_key = create_message_key(location)
-                timetable.del_for_partition(message_key, partition=partition)
-                schedule_index.del_for_partition(_request_id, partition=partition)
-                # Decrement the live count for this timekey
-                live_key = f"{loc_time_key}{TK_LIVE_SUFFIX}"
-                live_value = timetable.get_for_partition(live_key, partition=partition)
-                live_count = self._live_count_from_value(live_value)
-                if live_count > 0:
-                    timetable.update_for_partition(
-                        {
-                            live_key: self._next_live_value(
-                                live_count - 1, existing=live_value
-                            )
-                        },
-                        partition=partition,
+                if index_entry:
+                    loc_time_key = index_entry["tk"]
+                    loc_sequence = index_entry["seq"]
+                    location = TTLocation(partition, loc_time_key, loc_sequence)
+                    message_key = create_message_key(location)
+                    timetable.del_for_partition(message_key, partition=partition)
+                    schedule_index.del_for_partition(_request_id, partition=partition)
+                    # Decrement the live count for this timekey
+                    live_key = f"{loc_time_key}{TK_LIVE_SUFFIX}"
+                    live_value = timetable.get_for_partition(
+                        live_key, partition=partition
                     )
-                self.log.dev(
-                    f"Canceled scheduled message: {_request_id} at {location}"
-                )
-                continue
+                    live_count = self._live_count_from_value(live_value)
+                    if live_count > 0:
+                        timetable.update_for_partition(
+                            {
+                                live_key: self._next_live_value(
+                                    live_count - 1, existing=live_value
+                                )
+                            },
+                            partition=partition,
+                        )
+                    self.log.dev(
+                        f"{_action}: removed existing scheduled message: {_request_id} at {location}"
+                    )
+                    if _action == SCHEDULER_ACTION_REPLACE:
+                        self.replaced_total[partition] += 1
+                        self.monitor.on_message_replaced(partition=partition)
+                    elif _action == SCHEDULER_ACTION_CANCEL:
+                        self.canceled_total[partition] += 1
+                        self.monitor.on_message_canceled(partition=partition)
 
-            if _action == SCHEDULER_ACTION_ADD:
+                if _action == SCHEDULER_ACTION_CANCEL:
+                    continue
+
+            if _action in (SCHEDULER_ACTION_ADD, SCHEDULER_ACTION_REPLACE):
+                if not deliver_at or not deliver_to:
+                    self.log.warning(
+                        f"{_action}: missing deliver_at or deliver_to, skipping"
+                    )
+                    continue
                 _topic_name = deliver_to.decode()
                 time_key = str(deliver_at.decode())
 
@@ -652,14 +697,6 @@ class MessageScheduler(MessageSchedulerT, Service):
                 )
                 location = TTLocation(partition, int(time_key), sequence=message_total)
                 message_key = create_message_key(location)
-
-                _request_id = None
-                if request_id:
-                    _request_id = (
-                        request_id.decode()
-                        if isinstance(request_id, bytes)
-                        else request_id
-                    )
 
                 kms_meta = {"d": deliver_to.decode()}
                 if _request_id:
@@ -751,10 +788,28 @@ class MessageScheduler(MessageSchedulerT, Service):
                 }
                 headers = event.headers or {}
                 headers.update(scheduler_headers)
+                _partition = self._request_partition(actions_topic, request_id)
+                send_kwargs = {"partition": _partition} if _partition is not None else {}
                 await actions_topic.send(
                     key=event.message.key,
                     value=event.message.value,
                     headers=headers,
+                    **send_kwargs,
+                )
+                continue
+
+            # --- REPLACE: request_id required ---
+            if _action == SCHEDULER_ACTION_REPLACE and not request_id:
+                error_entry = {
+                    "key": event.key,
+                    "value": event.value,
+                    "headers": event.headers,
+                    "errors": [
+                        f"Missing required header `{H_SCHEDULER_REQUEST_ID}` for REPLACE action"
+                    ],
+                }
+                await rejections_topic.send(
+                    key=event.key, value=json_codec.dumps(error_entry)
                 )
                 continue
 
@@ -817,8 +872,13 @@ class MessageScheduler(MessageSchedulerT, Service):
                 scheduler_headers[H_SCHEDULER_REQUEST_ID] = request_id
             headers = event.headers or {}
             headers.update(scheduler_headers)
+            _partition = self._request_partition(actions_topic, request_id)
+            send_kwargs = {"partition": _partition} if _partition is not None else {}
             await actions_topic.send(
-                key=event.message.key, value=event.message.value, headers=headers
+                key=event.message.key,
+                value=event.message.value,
+                headers=headers,
+                **send_kwargs,
             )
 
     @Service.task

--- a/kaspr/sensors/kaspr.py
+++ b/kaspr/sensors/kaspr.py
@@ -189,6 +189,10 @@ class KasprMonitor(Monitor):
     #: since startup by partition
     replaced_total: Mapping[int, int]
 
+    #: Number of REPLACE actions that were no-ops due to identical schedule
+    #: since startup by partition
+    replace_noop_total: Mapping[int, int]
+
     #: Number of CANCEL actions that canceled an existing schedule
     #: since startup by partition
     canceled_total: Mapping[int, int]
@@ -233,6 +237,7 @@ class KasprMonitor(Monitor):
         self.scheduled_total = defaultdict(int)
         self.instant_send_total = defaultdict(int)
         self.replaced_total = defaultdict(int)
+        self.replace_noop_total = defaultdict(int)
         self.canceled_total = defaultdict(int)
         self.infra = InfraState() if infra is None else infra
         self.dispatchers = {} if dispatchers is None else dispatchers
@@ -342,6 +347,10 @@ class KasprMonitor(Monitor):
     def on_message_canceled(self, partition: int):
         """Call when CANCEL action removes an existing schedule entry."""
         self.canceled_total[partition] += 1
+
+    def on_message_replace_noop(self, partition: int):
+        """Call when REPLACE short-circuits because schedule is identical."""
+        self.replace_noop_total[partition] += 1
 
     def on_dispatcher_paused(self, dispatcher: DispatcherT):
         """Call when dispatcher paused processing."""

--- a/kaspr/sensors/kaspr.py
+++ b/kaspr/sensors/kaspr.py
@@ -185,6 +185,14 @@ class KasprMonitor(Monitor):
     #: already past due (since startup by partition)
     instant_send_total: Mapping[int, int]
 
+    #: Number of REPLACE actions that replaced an existing schedule
+    #: since startup by partition
+    replaced_total: Mapping[int, int]
+
+    #: Number of CANCEL actions that canceled an existing schedule
+    #: since startup by partition
+    canceled_total: Mapping[int, int]
+
     #: Infrastructure information
     infra: InfraState = None
 
@@ -224,6 +232,8 @@ class KasprMonitor(Monitor):
         self.process = psutil.Process(os.getpid())
         self.scheduled_total = defaultdict(int)
         self.instant_send_total = defaultdict(int)
+        self.replaced_total = defaultdict(int)
+        self.canceled_total = defaultdict(int)
         self.infra = InfraState() if infra is None else infra
         self.dispatchers = {} if dispatchers is None else dispatchers
         self.dispatchers_by_partition = (
@@ -324,6 +334,14 @@ class KasprMonitor(Monitor):
     def on_message_removed(self, janitor: JanitorT, location: TTLocation):
         """Call when a message is removed from Timetable."""
         self._janitor_or_create(janitor).messages_removed += 1
+
+    def on_message_replaced(self, partition: int):
+        """Call when REPLACE action updates an existing schedule entry."""
+        self.replaced_total[partition] += 1
+
+    def on_message_canceled(self, partition: int):
+        """Call when CANCEL action removes an existing schedule entry."""
+        self.canceled_total[partition] += 1
 
     def on_dispatcher_paused(self, dispatcher: DispatcherT):
         """Call when dispatcher paused processing."""

--- a/kaspr/sensors/prometheus_monitor.py
+++ b/kaspr/sensors/prometheus_monitor.py
@@ -454,6 +454,20 @@ class PrometheusMonitor(KasprMonitor):
                     *common_label_keys,
                 ],
             )
+            self.messages_replaced = Counter(
+                f"{prefix}kms_messages_replaced",
+                "Total REPLACE actions that replaced an existing schedule",
+                labelnames=[
+                    *common_label_keys,
+                ],
+            )
+            self.messages_canceled = Counter(
+                f"{prefix}kms_messages_canceled",
+                "Total CANCEL actions that removed an existing schedule",
+                labelnames=[
+                    *common_label_keys,
+                ],
+            )
             self.active_deliveries = Gauge(
                 f"{prefix}kms_active_deliveries",
                 "Messages delievered during uptime.",
@@ -594,6 +608,16 @@ class PrometheusMonitor(KasprMonitor):
         """Call when a message is removed from Timetable."""
         super().on_message_removed(janitor, location)
         self.messages_removed.labels(**self.common_labels).inc()
+
+    def on_message_replaced(self, partition: int):
+        """Call when a REPLACE action updates an existing schedule entry."""
+        super().on_message_replaced(partition)
+        self.messages_replaced.labels(**self.common_labels).inc()
+
+    def on_message_canceled(self, partition: int):
+        """Call when a CANCEL action removes an existing schedule entry."""
+        super().on_message_canceled(partition)
+        self.messages_canceled.labels(**self.common_labels).inc()
 
     def on_memory_stats_refreshed(self):
         """Memory usage stats updated."""

--- a/kaspr/sensors/prometheus_monitor.py
+++ b/kaspr/sensors/prometheus_monitor.py
@@ -461,6 +461,13 @@ class PrometheusMonitor(KasprMonitor):
                     *common_label_keys,
                 ],
             )
+            self.messages_replace_noop = Counter(
+                f"{prefix}kms_messages_replace_noop",
+                "Total REPLACE actions that were no-ops due to identical schedules",
+                labelnames=[
+                    *common_label_keys,
+                ],
+            )
             self.messages_canceled = Counter(
                 f"{prefix}kms_messages_canceled",
                 "Total CANCEL actions that removed an existing schedule",
@@ -618,6 +625,11 @@ class PrometheusMonitor(KasprMonitor):
         """Call when a CANCEL action removes an existing schedule entry."""
         super().on_message_canceled(partition)
         self.messages_canceled.labels(**self.common_labels).inc()
+
+    def on_message_replace_noop(self, partition: int):
+        """Call when REPLACE short-circuits because schedule is identical."""
+        super().on_message_replace_noop(partition)
+        self.messages_replace_noop.labels(**self.common_labels).inc()
 
     def on_memory_stats_refreshed(self):
         """Memory usage stats updated."""


### PR DESCRIPTION
This pull request introduces significant enhancements to the scheduling system, primarily adding support for a new "REPLACE" action that allows scheduled messages to be replaced in a safe and idempotent way. It also improves observability by tracking statistics for replace and cancel actions, and ensures more robust handling of request IDs and partitioning. Below are the most important changes grouped by theme:

### New "REPLACE" Scheduling Action

* Added a new `SCHEDULER_ACTION_REPLACE` action, allowing clients to atomically replace an existing scheduled message by `request_id`. The system checks for strict identity (using a fingerprint) to avoid unnecessary updates and supports no-op detection if the schedule is unchanged. [[1]](diffhunk://#diff-bba188f9b73a9aa87d27deffec3081adc17a569afa3ed75656e1b56198a63664R41) [[2]](diffhunk://#diff-bba188f9b73a9aa87d27deffec3081adc17a569afa3ed75656e1b56198a63664L585-R759) [[3]](diffhunk://#diff-bba188f9b73a9aa87d27deffec3081adc17a569afa3ed75656e1b56198a63664L656-R822)
* Implemented fingerprinting of scheduled messages for strict identity checks, ensuring that REPLACE actions are idempotent and only update when necessary. [[1]](diffhunk://#diff-bba188f9b73a9aa87d27deffec3081adc17a569afa3ed75656e1b56198a63664R433-R487) [[2]](diffhunk://#diff-bba188f9b73a9aa87d27deffec3081adc17a569afa3ed75656e1b56198a63664L656-R822) [[3]](diffhunk://#diff-bba188f9b73a9aa87d27deffec3081adc17a569afa3ed75656e1b56198a63664R844)

### Index and Message Removal Improvements

* Updated the janitor to remove reverse index entries keyed by `request_id` when a scheduled row is deleted, ensuring index consistency. [[1]](diffhunk://#diff-52e970b36f96909ba136d2f5428eccb1fcece3ad012f87836cb34d81d8405c5fR317) [[2]](diffhunk://#diff-52e970b36f96909ba136d2f5428eccb1fcece3ad012f87836cb34d81d8405c5fR326-R348)

### Partitioning and Distribution Logic

* Enhanced message distribution to deterministically route actions (especially REPLACE) to the correct partition based on `request_id`, improving correctness and scalability. [[1]](diffhunk://#diff-bba188f9b73a9aa87d27deffec3081adc17a569afa3ed75656e1b56198a63664R894-R916) [[2]](diffhunk://#diff-bba188f9b73a9aa87d27deffec3081adc17a569afa3ed75656e1b56198a63664R979-R986)

### Observability and Metrics

* Added tracking for the number of REPLACE actions that replaced a schedule, REPLACE no-ops (identical schedules), and CANCEL actions, with new metrics and log table columns for better monitoring and debugging. [[1]](diffhunk://#diff-bba188f9b73a9aa87d27deffec3081adc17a569afa3ed75656e1b56198a63664R70-R81) [[2]](diffhunk://#diff-bba188f9b73a9aa87d27deffec3081adc17a569afa3ed75656e1b56198a63664R92-R94) [[3]](diffhunk://#diff-bba188f9b73a9aa87d27deffec3081adc17a569afa3ed75656e1b56198a63664R577-R579) [[4]](diffhunk://#diff-bba188f9b73a9aa87d27deffec3081adc17a569afa3ed75656e1b56198a63664R601-R603) [[5]](diffhunk://#diff-bba188f9b73a9aa87d27deffec3081adc17a569afa3ed75656e1b56198a63664R620-R622) [[6]](diffhunk://#diff-c3be3e40dd11c65fa994b5fb2adbf518e8994e25207398a59b101df6346b27a3R188-R199) [[7]](diffhunk://#diff-c3be3e40dd11c65fa994b5fb2adbf518e8994e25207398a59b101df6346b27a3R239-R241)
* Updated the monitor to record and expose these new statistics, enabling more granular operational insights. [[1]](diffhunk://#diff-c3be3e40dd11c65fa994b5fb2adbf518e8994e25207398a59b101df6346b27a3R188-R199) [[2]](diffhunk://#diff-c3be3e40dd11c65fa994b5fb2adbf518e8994e25207398a59b101df6346b27a3R239-R241)

### Miscellaneous

* Bumped the package version from `0.10.2` to `0.10.3` to reflect these new features and improvements.